### PR TITLE
Fix VRCX icon wget

### DIFF
--- a/install-vrcx.sh
+++ b/install-vrcx.sh
@@ -72,7 +72,7 @@ if [[ -d $HOME/.local/share/applications ]]; then
 	if [[ ! -f $HOME/.local/share/icons/VRCX.png ]]; then
 		echo "Install VRCX.png to ~/.local/share/icons"
 		cd ~/.local/share/icons/
-		wget -q --show-progress https://github.com/vrcx-team/VRCX/blob/v2023.12.24/VRCX.png
+		wget -q --show-progress https://raw.githubusercontent.com/vrcx-team/VRCX/v2023.12.24/VRCX.png
 	fi
 
 	echo "Install vrcx.desktop to ~/.local/share/applications"


### PR DESCRIPTION
Not entirely sure if this old behavior that changed but wget is fetching the Github preview page for the icon, not the icon file itself. This causes VRCX to have no icon in KDE since its not an actual icon:
![image](https://github.com/galister/VRCX/assets/126194895/89254ab8-6792-4158-86e5-a326349d04b7)
