### PR TITLE
Add corefonts pull to fix whitescreen

### DIFF
--- a/install-vrcx.sh
+++ b/install-vrcx.sh
@@ -47,6 +47,8 @@ if [[ -d $vrc_appdata ]] && [[ ! -d $vrc_dst ]]; then
 	ln -s $vrc_appdata $vrc_dst
 fi
 
+winetricks --force -q corefonts
+
 echo "Download VRCX"
 
 if [[ ! -d $WINEPREFIX/drive_c/vrcx ]]; then

--- a/install-vrcx.sh
+++ b/install-vrcx.sh
@@ -15,6 +15,12 @@ if [ "$1" != "force" ] && [[ $wine_version < 9.0 ]]; then
 	exit 1
 fi
 
+if ! [ -x "$(command -v winetricks)" ]; then
+  echo "You don't have winetricks installed or 'command -v winetricks' doesn't recongize it, you will want it for corefonts."
+  exit 1
+fi
+
+
 if [[ ! -d $WINEPREFIX ]]; then
 	echo "Creating Wine prefix."
 	logs=$(winecfg /v win10 2>&1)


### PR DESCRIPTION
Another fix I'm not entirely sure about, I'd open a discussion or issue but it's closed here.

On my Arch system with Wine 9.4, booting up VRCX from the script alone, VRCX boots up with a whitescreen and is seemingly dead (can't open inspector, etc).

![Screenshot_20240323_175905](https://github.com/galister/VRCX/assets/126194895/68b7f420-26e7-47c0-97e7-a7c053d12bd2)

After pulling corefonts per `WINEPREFIX=$HOME/.local/share/vrcx winetricks --force -q corefonts`, [as per wiki instructions](https://github.com/vrcx-team/VRCX/wiki/Running-VRCX-on-Linux), it works again:

![Screenshot_20240323_180652](https://github.com/galister/VRCX/assets/126194895/1b419725-3f84-46e5-80a9-2af070824d48)

Maybe it's a me or a Wayland issue, but this should be incredibly easy to reproduce.

Obviously using winetricks will introduce winetricks as dependency for the script.